### PR TITLE
Add parametrized unit tests for DateFormat function

### DIFF
--- a/Tests/stylusTests/DateFormatTests.swift
+++ b/Tests/stylusTests/DateFormatTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+@testable import stylus
+import Testing
+
+// MARK: - DateFormatTests
+
+@Suite("DateFormatTests")
+struct DateFormatTests {
+    @Test(arguments: [
+        ("yyyy-MM-dd", 1_609_459_200.0, "2021-01-01"),
+        ("dd/MM/yy", 1_609_459_200.0, "01/01/21"),
+        ("dd MMMM yyyy", 1_609_459_200.0, "01 January 2021"),
+        ("dd MMM yyyy", 1_609_459_200.0, "01 Jan 2021"),
+        ("yyyy/MM/dd", 1_609_459_200.0, "2021/01/01"),
+        ("", 1_609_459_200.0, ""),
+        ("yyyy-MM-dd", 1_640_995_200.0, "2022-01-01"),
+        ("yyyy_MM_dd", 1_609_459_200.0, "2021_01_01"),
+    ])
+    func formatsDateWithPattern(format: String, timestamp: TimeInterval, expected: String) {
+        let date = Date(timeIntervalSince1970: timestamp)
+        let result = formatDate(format, date: date)
+        #expect(result == expected)
+    }
+}


### PR DESCRIPTION
## Changes
- Add comprehensive test suite for `formatDate` function using Swift Testing framework
- Implement parametrized tests with `@Test(arguments:)` for cleaner, more maintainable tests
- Test various date format patterns: `yyyy-MM-dd`, `dd/MM/yy`, month names, custom separators
- Test with multiple timestamps to verify correctness
- Cover edge cases like empty format string

## Test Coverage
- 8 parametrized test cases covering different format patterns
- Tests date formatting with specific dates (2021-01-01, 2022-01-01)
- Validates proper formatting of dates, months, years, and custom separators

All tests pass successfully ✅