### PR TITLE
Add mise flush task for beads database sync

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -2,3 +2,7 @@
 "go:github.com/idursun/jjui/cmd/jjui" = "latest"
 "go:github.com/steveyegge/beads/cmd/bd" = "latest"
 swiftformat = "latest"
+
+[tasks.flush]
+run = "bd sync --flush-only"
+description = "Flush beads database to sync with git"


### PR DESCRIPTION
Adds a new 'flush' task to mise.toml that executes 'bd sync --flush-only' to flush the beads database and sync with git. This provides a convenient way to manually trigger database synchronization when needed.